### PR TITLE
Mac build support

### DIFF
--- a/MACBUILD.md
+++ b/MACBUILD.md
@@ -1,0 +1,7 @@
+To compile for MacOS:
+
+Within the zulu-wheel diretory - 
+npm install
+npm run make:mac
+
+.dmg file will be created in /out/make/Zulu Wheel.dmg of the zulu-wheel directory

--- a/angular.json
+++ b/angular.json
@@ -48,8 +48,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "1.5MB",
+                  "maximumError": "2MB"
                 },
                 {
                   "type": "anyComponentStyle",
@@ -106,5 +106,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/app.js
+++ b/app.js
@@ -9,7 +9,11 @@ const http = require('http');
 const { updateElectronApp } = require('update-electron-app');
 
 if (require('electron-squirrel-startup')) app.quit();
-updateElectronApp(); 
+
+// Only use auto-updater if not on macOS (since we're not signing the macOS build)
+if (process.platform !== 'darwin') {
+    updateElectronApp();
+}
 
 let mainWindow
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,0 +1,50 @@
+module.exports = {
+  packagerConfig: {
+    asar: true,
+    osxSign: false, // Disable code signing
+    osxNotarize: false, // Disable notarization
+    icon: './public/favicon',
+    extraResource: [
+      './public'
+    ]
+  },
+  rebuildConfig: {},
+  makers: [
+    {
+      name: '@electron-forge/maker-squirrel',
+      config: {},
+    },
+    {
+      name: '@electron-forge/maker-zip',
+      platforms: ['darwin'],
+    },
+    {
+      name: '@electron-forge/maker-deb',
+      config: {},
+    },
+    {
+      name: '@electron-forge/maker-rpm',
+      config: {},
+    },
+    {
+      name: '@electron-forge/maker-dmg',
+      config: {
+        format: 'ULFO',
+        name: 'Zulu Wheel',
+        icon: './public/favicon.ico',
+        contents: options => {
+          return [
+            { x: 448, y: 344, type: 'link', path: '/Applications' },
+            { x: 192, y: 344, type: 'file', path: options.appPath }
+          ];
+        }
+      }
+    }
+  ],
+  plugins: [
+    {
+      name: '@electron-forge/plugin-auto-unpack-natives',
+      config: {},
+    },
+  ],
+}; 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "startprod": "ng build --base-href ./ --configuration production && electron .",
     "package": "electron-forge package",
     "make": "electron-forge make",
+    "make:mac": "ng build --base-href ./ --configuration production && electron-forge make --platform=darwin",
     "publish": "electron-forge publish"
   },
   "dependencies": {
@@ -49,6 +50,7 @@
     "@angular/compiler-cli": "^18.2.0",
     "@electron-forge/cli": "^7.6.0",
     "@electron-forge/maker-deb": "^7.6.0",
+    "@electron-forge/maker-dmg": "^7.7.0",
     "@electron-forge/maker-rpm": "^7.6.0",
     "@electron-forge/maker-squirrel": "^7.6.0",
     "@electron-forge/maker-wix": "^7.6.1",


### PR DESCRIPTION
These changes are to add the ability to build an unsigned MacOS .dmg bundle

- Created MACBUILD.md with instructions on building MacOS from source
- Created forge.config.js needed for MacOS Build
- Added Line 14 of package.json
- Modifed lines 51-52 of angular.json